### PR TITLE
Fix turbo timer handling

### DIFF
--- a/NavesJogo/Meujogo/modelo/Fase.java
+++ b/NavesJogo/Meujogo/modelo/Fase.java
@@ -101,6 +101,8 @@ public class Fase extends JPanel implements ActionListener{
         player.update();
         if (player.isTurbo() == true) {
             timer.setDelay(2);
+        } else {
+            timer.setDelay(5);
         }
 
         for(int p = 0; p < stars.size(); p++){

--- a/NavesJogo/Meujogo/modelo/Player.java
+++ b/NavesJogo/Meujogo/modelo/Player.java
@@ -29,22 +29,17 @@ public class Player implements ActionListener {
         tiros = new ArrayList<Tiro>();
 
         timer = new Timer(5000, this);
-        timer.start();
+        timer.setRepeats(false);
 
         load();
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        if (isTurbo == true) {
-            turbo();
+        if (isTurbo) {
             isTurbo = false;
-        }
-        if (isTurbo == false) {
             load();
         }
-        
-        
     }
 
 
@@ -69,6 +64,7 @@ public class Player implements ActionListener {
         isTurbo = true;
         ImageIcon referencia = new ImageIcon(getClass().getResource("/res/naveturbo.png"));
         imagem = referencia.getImage();
+        timer.restart();
     }
 
     public Rectangle getBounds(){


### PR DESCRIPTION
## Summary
- make player's turbo timer a single-shot timer that starts when turbo activates
- restore normal timer speed in `Fase.actionPerformed`

## Testing
- `find NavesJogo -name "*.java" | xargs javac`

------
https://chatgpt.com/codex/tasks/task_e_6887adf405e083258b6fe52c2d29bb0d