### PR TITLE
Enable in-game restart with R key

### DIFF
--- a/NavesJogo/Meujogo/modelo/Fase.java
+++ b/NavesJogo/Meujogo/modelo/Fase.java
@@ -25,6 +25,14 @@ public class Fase extends JPanel implements ActionListener{
     private List<Stars> stars;
     private boolean emJogo;
 
+    private void reiniciarJogo(){
+        player = new Player();
+        inicializaInimigos();
+        inicializaEstrelas();
+        emJogo = true;
+        requestFocusInWindow();
+    }
+
     public Fase(){
         setFocusable(true);
         setDoubleBuffered(true);
@@ -179,6 +187,10 @@ public class Fase extends JPanel implements ActionListener{
     private class TecladoAdapter extends KeyAdapter{
         @Override
         public void keyPressed(KeyEvent e){
+            if(!emJogo && e.getKeyCode() == KeyEvent.VK_R){
+                reiniciarJogo();
+                return;
+            }
             player.keyPressed(e);
         }
 


### PR DESCRIPTION
## Summary
- add `reiniciarJogo` helper to reset player, enemies and stars
- restart the game when R is pressed after game over

## Testing
- `javac -d bin NavesJogo/Meujogo/Container.java NavesJogo/Meujogo/modelo/*.java`
- `cp -r NavesJogo/res bin/res`
- `java -cp bin Meujogo.Container` *(fails: HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_e_6887b9c9d1888325ae6dbc969ddcc9b1